### PR TITLE
The summarize() function should not sort by time

### DIFF
--- a/lib/speedsnitch.js
+++ b/lib/speedsnitch.js
@@ -1,65 +1,82 @@
 /*
  * ghetto-profiler
- * 
+ *
  *
  * Copyright (c) 2012 Alan Clarke
  * Licensed under the MIT license.
  */
 
-var Snitch = function(log){
-	this.opts = { log:log };
-	this.data = [];
+var Snitch = function (log) {
+    this.opts = {
+        log: log
+    };
+    this.data = [];
 };
 
 Snitch.prototype = {
-	next: function(name){
-		var s = this;
-		var last = s.stop();
-		s.data.push({ name:name, start:s._capture()});
-		return last;
-	},
-	stop: function(){
-		var s = this;
-		if(s.data.length){
-			var last = s.data[s.data.length-1];
-				if(!last.stop){
-				last.stop = s._capture();
-				last.ms = last.stop.time- last.start.time;
+    next: function (name) {
+        var s = this;
+        var last = s.stop();
+        s.data.push({
+            name: name,
+            start: s._capture()
+        });
+        return last;
+    },
+    stop: function () {
+        var s = this;
+        if (s.data.length) {
+            var last = s.data[s.data.length - 1];
+            if (!last.stop) {
+                last.stop = s._capture();
+                last.ms = last.stop.time - last.start.time;
 
-				if(s.opts.log){
-					console.log(last);
-				}
-				return last;
-			}
-		}
-	},
-	_capture:function(){
-		var e = new Error();
-		var index = 3;
-		var callee_stack =  e.stack.split('\n');
-		for(var i =0;i<callee_stack.length;i++){
-			if(callee_stack[i].indexOf(__filename.replace(/^.*\//,''))>=0){
-				index = i+1;
-			}
-		}
-		callee_stack = callee_stack[index].split(':');
-		return { time: new Date().valueOf(), file:callee_stack[0].replace(/^.*\//,''), line:callee_stack[1] };
-	},
-	summarize: function(){
-		var s = this;
-		var last = s.stop();
-		var data = s.data.sort(function(a,b){ return b.ms - a.ms; });
-		if(s.opts.log){
-			console.log(data);
-		}
-		return data;
-	},
-	summarise: function(){
-		return this.summarize();
-	}
+                if (s.opts.log) {
+                    console.log(last);
+                }
+                return last;
+            }
+        }
+    },
+    _capture: function () {
+        var e = new Error();
+        var index = 3;
+        var callee_stack = e.stack.split('\n');
+        for (var i = 0; i < callee_stack.length; i++) {
+            if (callee_stack[i].indexOf(__filename.replace(/^.*\//, '')) >= 0) {
+                index = i + 1;
+            }
+        }
+        callee_stack = callee_stack[index].split(':');
+        return {
+            time: new Date().valueOf(),
+            file: callee_stack[0].replace(/^.*\//, ''),
+            line: callee_stack[1]
+        };
+    },
+    summarize: function () {
+        var s = this;
+        var last = s.stop();
+        var data = s.data;
+        if (s.opts.log) {
+            console.log(data);
+        }
+        return data;
+    },
+    summarise: function () {
+        return this.summarize();
+    },
+    sortedSummary: function () {
+        var s = this;
+        var last = s.stop();
+        var data = s.data.sort(function (a, b) {
+            return b.ms - a.ms;
+        });
+        if (s.opts.log) {
+            console.log(data);
+        }
+        return data;
+    }
 };
 
 module.exports = Snitch;
-
-
-


### PR DESCRIPTION
The function summarize() should not sort the stack by time. This will allow to obtain an in-order sequence of visits to better understand the stack. Instead, a new function sortedSummary() should be added, performing the same action as the old summarize() implementation.

With this addition, we can obtain two different views of the same stack.
